### PR TITLE
PS-652_indexer-wrong-dispatch-level2

### DIFF
--- a/databox/indexer/src/handlers/phraseanet/CPhraseanetRecord.ts
+++ b/databox/indexer/src/handlers/phraseanet/CPhraseanetRecord.ts
@@ -41,12 +41,21 @@ class CPhraseanetRecordBase {
         this.subdefs = r.subdefs;
         this.status = r.status;
         r.metadata.map((m) => {
-            if(!this.metadata[m.name]) {
-                this.metadata[m.name] = CPhraseanetMetadata.fromTPhraseanetMetadata(m);
+            if(m.value.trim() !== '') {
+                if (!this.metadata[m.name]) {
+                    this.metadata[m.name] = CPhraseanetMetadata.fromTPhraseanetMetadata(m);
+                }
+                this.metadata[m.name].values.push(m.value);
             }
-            this.metadata[m.name].values.push(m.value);
         })
+
         for(const k in this.metadata) {
+            this.metadata[k].values.sort(
+                (a, b) => {
+                    a = a.toLowerCase(); b = b.toLowerCase();
+                    return a < b ? -1 : (a > b ? 1 : 0);
+                }
+            );
             this.metadata[k].value = this.metadata[k].values.join(' ; ')
         }
     }

--- a/databox/indexer/src/handlers/phraseanet/CPhraseanetSubdef.ts
+++ b/databox/indexer/src/handlers/phraseanet/CPhraseanetSubdef.ts
@@ -1,0 +1,35 @@
+import {PhraseanetSubdef} from "./types";
+
+export class CPhraseanetSubdef {
+    name?: string;
+    height?: number;
+    width?: number;
+    filesize?: number;
+    player_type?: string;
+    mime_type?: string;
+    created_on?: string;
+    updated_on?: string;
+    url?: string;
+    permalink?: {
+        url?: string;
+    };
+
+    static NullSubdef = new CPhraseanetSubdef();
+
+    constructor(s?: PhraseanetSubdef) {
+        if(s) {
+            this.name = s.name;
+            this.height = s.height;
+            this.width = s.width;
+            this.filesize = s.filesize;
+            this.player_type = s.player_type;
+            this.mime_type = s.mime_type;
+            this.created_on = s.created_on;
+            this.updated_on = s.updated_on;
+            this.url = s.url;
+            this.permalink = s.permalink;
+        }
+    }
+
+}
+

--- a/databox/indexer/src/handlers/phraseanet/indexer.ts
+++ b/databox/indexer/src/handlers/phraseanet/indexer.ts
@@ -215,8 +215,8 @@ export const phraseanetIndexer: IndexIterator<PhraseanetConfig> =
                 classIndex[rc.name] = rc.id;
             });
 
-            const subDefs = await client.getSubDefinitions(databox.databox_id);
-            for (const sd of subDefs) {
+            const subdefs = await client.getSubdefsStruct(databox.databox_id);
+            for (const sd of subdefs) {
                 if (!classIndex[sd.class]) {
                     logger.info(`Creating rendition class "${sd.class}" `);
                     classIndex[sd.class] =

--- a/databox/indexer/src/handlers/phraseanet/phraseanetClient.ts
+++ b/databox/indexer/src/handlers/phraseanet/phraseanetClient.ts
@@ -6,7 +6,7 @@ import {
     PhraseanetDatabox,
     PhraseanetMetaStruct,
     PhraseanetStatusBitStruct,
-    PhraseanetSubDef,
+    PhraseanetSubdefStruct,
     PhraseanetRecord,
     PhraseanetStory
 } from './types';
@@ -189,11 +189,11 @@ export default class PhraseanetClient {
         return res.data.response.status;
     }
 
-    async getSubDefinitions(databoxId?: string): Promise<PhraseanetSubDef[]> {
+    async getSubdefsStruct(databoxId?: string): Promise<PhraseanetSubdefStruct[]> {
         const dbid = typeof databoxId !== 'undefined' ? '/' + databoxId : '';
         const res = await this.client.get(`/api/v3/databoxes${dbid}/subdefs/`);
 
-        const subdefs: PhraseanetSubDef[] = [];
+        const subdefs: PhraseanetSubdefStruct[] = [];
 
         const dbxs = res.data.response.databoxes;
         Object.keys(dbxs).forEach(id => {

--- a/databox/indexer/src/handlers/phraseanet/shared.ts
+++ b/databox/indexer/src/handlers/phraseanet/shared.ts
@@ -1,5 +1,5 @@
 import {Asset} from '../../indexers';
-import {FieldMap, SubDef} from './types';
+import {FieldMap, PhraseanetSubdef} from './types';
 import { CPhraseanetRecord } from './CPhraseanetRecord';
 
 import {
@@ -36,7 +36,7 @@ export async function createAsset(
     tagIndex: TagIndex,
     shortcutIntoCollections: {id: string, path: string}[]
 ): Promise<Asset> {
-    const document: SubDef | undefined = record.subdefs.find(
+    const document: PhraseanetSubdef | undefined = record.subdefs.find(
         s => s.name === 'document'
     );
 

--- a/databox/indexer/src/handlers/phraseanet/types.d.ts
+++ b/databox/indexer/src/handlers/phraseanet/types.d.ts
@@ -48,14 +48,6 @@ export type PhraseanetConfig = {
     databoxMapping: ConfigDataboxMapping[];
 };
 
-export type SubDef = {
-    name: string;
-    mime_type?: string;
-    permalink: {
-        url: string;
-    };
-};
-
 export enum PhraseanetMetadataType {
     Date = "date",
     Number = "number",
@@ -89,7 +81,7 @@ export type PhraseanetStatusBit = {
     state: boolean;
 };
 
-export type PhraseanetSubDef = {
+export type PhraseanetSubdefStruct = {
     type: string; // image | video | audio | document
     name: string; // thumbnail, thumbnail_gif, preview, preview_webm ...
     databox_id: number;
@@ -99,6 +91,21 @@ export type PhraseanetSubDef = {
     devices: string[];
     labels: Record<string, string>;
     options: Record<string, any>;
+};
+
+export type PhraseanetSubdef = {
+    name: string;
+    height: number;
+    width: number;
+    filesize: number;
+    player_type: string;
+    mime_type: string;
+    created_on: string;
+    updated_on: string;
+    url: string;
+    permalink: {
+        url: string;
+    };
 };
 
 export type PhraseanetDatabox = {
@@ -134,7 +141,10 @@ export type PhraseanetRecord = {
     uuid: string;
     title: string;
     original_name: string;
-    subdefs: SubDef[];
+    mime_type: string;
+    created_on: string;
+    updated_on: string;
+    subdefs: PhraseanetSubdef[];
     status: PhraseanetStatusBit[];
     metadata: PhraseanetMetadata[];
 };
@@ -148,7 +158,10 @@ export type PhraseanetStory = {
     uuid: string;
     title: string;
     original_name: string;
-    subdefs: SubDef[];
+    mime_type: string;
+    created_on: string;
+    updated_on: string;
+    subdefs: PhraseanetSubdef[];
     status: PhraseanetStatusBit[];
     metadata: PhraseanetMetadata[];
     children: PhraseanetRecord[];


### PR DESCRIPTION
- not changed: wrong dispatch was due to bad "copy_to" twig code during tests : the multi-values loop must wrap the entire line generation.
- fix: empty values dispatch & multi->mono order