### PR TITLE
PS-914_indexer-crash

### DIFF
--- a/databox/indexer/src/handlers/phraseanet/indexer.ts
+++ b/databox/indexer/src/handlers/phraseanet/indexer.ts
@@ -297,7 +297,8 @@ export const phraseanetIndexer: IndexIterator<PhraseanetConfig> =
                     searchParams,
                     0, // offset
                     PAGESIZE,
-                    query
+                    query,
+                    dm.importStories
                 );
                 for (const record of records) {
                     logger.info(

--- a/databox/indexer/src/handlers/phraseanet/indexer.ts
+++ b/databox/indexer/src/handlers/phraseanet/indexer.ts
@@ -298,7 +298,7 @@ export const phraseanetIndexer: IndexIterator<PhraseanetConfig> =
                     0, // offset
                     PAGESIZE,
                     query,
-                    dm.importStories
+                    dm.importStories ?? false
                 );
                 for (const record of records) {
                     logger.info(


### PR DESCRIPTION
fix old phraseanet (before [https://github.com/alchemy-fr/Phraseanet/pull/4602](https://github.com/alchemy-fr/Phraseanet/pull/4602)) records (add `stories[]` **only if** `importStories=false`)