### PR TITLE
PS-1228 feat: add privacy status to saved searches (secret, private, public)

### DIFF
--- a/databox/api/config/reference.php
+++ b/databox/api/config/reference.php
@@ -121,7 +121,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: array<class-string, InstanceofType>,
+ *     _instanceof?: InstanceofType,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>
@@ -593,7 +593,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
- *         enabled?: bool|Param, // Default: true
+ *         enabled?: bool|Param, // Default: false
  *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
  *         dsn?: scalar|Param|null, // Default: null
  *         transports?: array<string, scalar|Param|null>,

--- a/databox/api/migrations/Version20260803090000.php
+++ b/databox/api/migrations/Version20260803090000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260803090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace saved_search.public boolean with a privacy status (0=secret, 1=private, 2=public)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE saved_search ADD privacy SMALLINT DEFAULT 0 NOT NULL');
+        $this->addSql('UPDATE saved_search SET privacy = CASE WHEN public = true THEN 2 ELSE 0 END');
+        $this->addSql('ALTER TABLE saved_search DROP public');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE saved_search ADD public BOOLEAN DEFAULT false NOT NULL');
+        $this->addSql('UPDATE saved_search SET public = (privacy = 2)');
+        $this->addSql('ALTER TABLE saved_search DROP privacy');
+    }
+}

--- a/databox/api/src/Api/InputTransformer/SavedSearchInputTransformer.php
+++ b/databox/api/src/Api/InputTransformer/SavedSearchInputTransformer.php
@@ -7,6 +7,7 @@ namespace App\Api\InputTransformer;
 use App\Api\Model\Input\SavedSearchInput;
 use App\Api\Processor\WithOwnerIdProcessorTrait;
 use App\Entity\SavedSearch\SavedSearch;
+use App\Model\SavedSearchPrivacyEnum;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
 class SavedSearchInputTransformer extends AbstractFileInputTransformer
@@ -26,8 +27,8 @@ class SavedSearchInputTransformer extends AbstractFileInputTransformer
         /** @var SavedSearch $object */
         $object = $context[AbstractNormalizer::OBJECT_TO_POPULATE] ?? new SavedSearch();
 
-        if (null !== $data->public) {
-            $object->setPublic($data->public);
+        if (null !== $data->privacy) {
+            $object->setPrivacy(SavedSearchPrivacyEnum::from($data->privacy));
         }
 
         if (null !== $data->name) {

--- a/databox/api/src/Api/Model/Input/SavedSearchInput.php
+++ b/databox/api/src/Api/Model/Input/SavedSearchInput.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\Api\Model\Input;
 
+use App\Model\SavedSearchPrivacyEnum;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class SavedSearchInput extends AbstractOwnerIdInput
 {
     #[Assert\NotBlank]
     public ?string $name = null;
-    public ?bool $public = null;
+
+    #[Assert\Choice(callback: [SavedSearchPrivacyEnum::class, 'values'])]
+    public ?int $privacy = null;
 
     #[Assert\NotNull]
     public ?array $data = null;

--- a/databox/api/src/Api/Model/Output/SavedSearchOutput.php
+++ b/databox/api/src/Api/Model/Output/SavedSearchOutput.php
@@ -32,8 +32,12 @@ class SavedSearchOutput extends AbstractUuidOutput
     #[Groups([SavedSearch::GROUP_LIST, SavedSearch::GROUP_READ, WebhookSerializationInterface::DEFAULT_GROUP])]
     public ?string $name = null;
 
+    #[ApiProperty(jsonSchemaContext: [
+        'type' => 'integer',
+        'enum' => [0, 1, 2],
+    ])]
     #[Groups([SavedSearch::GROUP_LIST, WebhookSerializationInterface::DEFAULT_GROUP])]
-    public ?bool $public = null;
+    public ?int $privacy = null;
 
     #[Groups([SavedSearch::GROUP_READ])]
     public ?UserOutput $owner = null;

--- a/databox/api/src/Api/OutputTransformer/SavedSearchOutputTransformer.php
+++ b/databox/api/src/Api/OutputTransformer/SavedSearchOutputTransformer.php
@@ -39,7 +39,7 @@ class SavedSearchOutputTransformer implements OutputTransformerInterface
         $output->setId($data->getId());
 
         $output->name = $data->getName();
-        $output->public = $data->isPublic();
+        $output->privacy = $data->getPrivacy()->value;
         $output->data = $data->getData();
 
         if ($this->hasGroup([

--- a/databox/api/src/Controller/Admin/SavedSearchCrudController.php
+++ b/databox/api/src/Controller/Admin/SavedSearchCrudController.php
@@ -10,12 +10,13 @@ use Alchemy\AdminBundle\Field\JsonField;
 use Alchemy\AdminBundle\Field\UserChoiceField;
 use Alchemy\AdminBundle\Filter\UserChoiceFilter;
 use App\Entity\SavedSearch\SavedSearch;
+use App\Model\SavedSearchPrivacyEnum;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
-use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use EasyCorp\Bundle\EasyAdminBundle\Filter\BooleanFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\ChoiceFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
 
@@ -48,7 +49,7 @@ class SavedSearchCrudController extends AbstractAclAdminCrudController
     {
         return $filters
             ->add(TextFilter::new('name'))
-            ->add(BooleanFilter::new('public'))
+            ->add(ChoiceFilter::new('privacy')->setChoices(SavedSearchPrivacyEnum::getChoices()))
             ->add(DateTimeFilter::new('createdAt'))
             ->add(DateTimeFilter::new('updatedAt'))
             ->add($this->userChoiceFilter->createFilter('ownerId'))
@@ -62,8 +63,9 @@ class SavedSearchCrudController extends AbstractAclAdminCrudController
             ->hideOnForm();
         yield $this->userChoiceField->create('ownerId', 'Owner');
         yield TextField::new('name');
-        yield BooleanField::new('public')
-            ->renderAsSwitch(false)
+        yield ChoiceField::new('privacy')
+            ->setChoices(SavedSearchPrivacyEnum::getChoices())
+            ->setHelp('Secret: only the owner and granted users. Private: accessible by direct link but not listed. Public: listed to every user.')
         ;
         yield DateTimeField::new('updatedAt')
             ->hideOnForm();

--- a/databox/api/src/Entity/SavedSearch/SavedSearch.php
+++ b/databox/api/src/Entity/SavedSearch/SavedSearch.php
@@ -19,6 +19,7 @@ use App\Api\Model\Output\SavedSearchOutput;
 use App\Api\Provider\SavedSearchCollectionProvider;
 use App\Entity\Traits\OwnerIdTrait;
 use App\Entity\WithOwnerIdInterface;
+use App\Model\SavedSearchPrivacyEnum;
 use App\Repository\SavedSearch\SavedSearchRepository;
 use App\Security\Voter\AbstractVoter;
 use Doctrine\DBAL\Types\Types;
@@ -33,7 +34,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             normalizationContext: [
                 'groups' => [self::GROUP_LIST],
             ]),
-        new Get(),
+        new Get(security: 'is_granted("'.AbstractVoter::READ.'", object)'),
         new Delete(security: 'is_granted("'.AbstractVoter::DELETE.'", object)'),
         new Put(
             security: 'is_granted("'.AbstractVoter::EDIT.'", object)',
@@ -66,8 +67,8 @@ class SavedSearch extends AbstractUuidEntity implements WithOwnerIdInterface, Ac
     #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private ?string $name = null;
 
-    #[ORM\Column(type: Types::BOOLEAN, nullable: false)]
-    private bool $public = false;
+    #[ORM\Column(type: Types::SMALLINT, nullable: false, enumType: SavedSearchPrivacyEnum::class, options: ['default' => SavedSearchPrivacyEnum::Secret->value])]
+    private SavedSearchPrivacyEnum $privacy = SavedSearchPrivacyEnum::Secret;
 
     #[ORM\Column(type: Types::JSON, nullable: false)]
     private array $data = [];
@@ -107,13 +108,13 @@ class SavedSearch extends AbstractUuidEntity implements WithOwnerIdInterface, Ac
         return $this->getName() ?? 'SavedSearch - '.$this->getId();
     }
 
-    public function isPublic(): bool
+    public function getPrivacy(): SavedSearchPrivacyEnum
     {
-        return $this->public;
+        return $this->privacy;
     }
 
-    public function setPublic(bool $public): void
+    public function setPrivacy(SavedSearchPrivacyEnum $privacy): void
     {
-        $this->public = $public;
+        $this->privacy = $privacy;
     }
 }

--- a/databox/api/src/Model/SavedSearchPrivacyEnum.php
+++ b/databox/api/src/Model/SavedSearchPrivacyEnum.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+enum SavedSearchPrivacyEnum: int
+{
+    // Only the owner and granted users can see and access the search
+    case Secret = 0;
+
+    // Accessible by direct link but not listed to other users
+    case Private = 1;
+
+    // Listed to every user
+    case Public = 2;
+
+    public static function getChoices(): array
+    {
+        return [
+            'Secret' => self::Secret,
+            'Private' => self::Private,
+            'Public' => self::Public,
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $case): int => $case->value, self::cases());
+    }
+}

--- a/databox/api/src/Repository/SavedSearch/SavedSearchRepository.php
+++ b/databox/api/src/Repository/SavedSearch/SavedSearchRepository.php
@@ -7,6 +7,7 @@ namespace App\Repository\SavedSearch;
 use Alchemy\AclBundle\Entity\AccessControlEntryRepository;
 use Alchemy\AclBundle\Security\PermissionInterface;
 use App\Entity\SavedSearch\SavedSearch;
+use App\Model\SavedSearchPrivacyEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -36,10 +37,11 @@ class SavedSearchRepository extends ServiceEntityRepository
                 false,
             );
             $queryBuilder->setParameter('uid', $userId);
-            $queryBuilder->andWhere('t.public = true OR t.ownerId = :uid OR ace.id IS NOT NULL');
+            $queryBuilder->andWhere('t.privacy = :publicPrivacy OR t.ownerId = :uid OR ace.id IS NOT NULL');
         } else {
-            $queryBuilder->andWhere('t.public = true');
+            $queryBuilder->andWhere('t.privacy = :publicPrivacy');
         }
+        $queryBuilder->setParameter('publicPrivacy', SavedSearchPrivacyEnum::Public->value);
 
         return $queryBuilder;
     }

--- a/databox/api/src/Security/Voter/SavedSearchVoter.php
+++ b/databox/api/src/Security/Voter/SavedSearchVoter.php
@@ -7,6 +7,7 @@ namespace App\Security\Voter;
 use Alchemy\AclBundle\Security\PermissionInterface;
 use Alchemy\AuthBundle\Security\JwtUser;
 use App\Entity\SavedSearch\SavedSearch;
+use App\Model\SavedSearchPrivacyEnum;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class SavedSearchVoter extends AbstractVoter
@@ -39,7 +40,8 @@ class SavedSearchVoter extends AbstractVoter
 
         return match ($attribute) {
             self::CREATE => $this->isAuthenticated(),
-            self::READ => $isOwner()
+            self::READ => SavedSearchPrivacyEnum::Secret !== $subject->getPrivacy()
+                || $isOwner()
                 || $this->hasAcl(PermissionInterface::VIEW, $subject, $token),
             self::EDIT => $isOwner()
                 || $this->hasAcl(PermissionInterface::EDIT, $subject, $token),

--- a/databox/client/src/api/savedSearch.ts
+++ b/databox/client/src/api/savedSearch.ts
@@ -23,11 +23,25 @@ export async function getSavedSearches(
     return getHydraCollection(res.data);
 }
 
+function normalizeSavedSearch(
+    data: Partial<SavedSearch>
+): Partial<SavedSearch> {
+    if (data.privacy !== undefined) {
+        // Radio inputs yield string values while the API expects an integer
+        return {...data, privacy: Number(data.privacy)};
+    }
+
+    return data;
+}
+
 export async function putSavedSearch(
     id: string,
     data: Partial<SavedSearch>
 ): Promise<SavedSearch> {
-    const res = await apiClient.put(`/${EntityName.SavedSearch}/${id}`, data);
+    const res = await apiClient.put(
+        `/${EntityName.SavedSearch}/${id}`,
+        normalizeSavedSearch(data)
+    );
 
     return res.data;
 }
@@ -35,7 +49,10 @@ export async function putSavedSearch(
 export async function postSavedSearch(
     data: Partial<SavedSearch>
 ): Promise<SavedSearch> {
-    const res = await apiClient.post(`/${EntityName.SavedSearch}`, data);
+    const res = await apiClient.post(
+        `/${EntityName.SavedSearch}`,
+        normalizeSavedSearch(data)
+    );
 
     return res.data;
 }

--- a/databox/client/src/components/Media/Search/SavedSearch/SaveSearchDialog.tsx
+++ b/databox/client/src/components/Media/Search/SavedSearch/SaveSearchDialog.tsx
@@ -4,7 +4,7 @@ import {StackedModalProps, useFormPrompt, useModals} from '@alchemy/navigation';
 import React from 'react';
 import {AppDialog} from '@alchemy/phrasea-ui';
 import {TSearchContext} from '../SearchContext.tsx';
-import {SavedSearch} from '../../../../types.ts';
+import {SavedSearch, SavedSearchPrivacy} from '../../../../types.ts';
 import {toast} from 'react-toastify';
 import {useFormSubmit} from '@alchemy/api';
 import {getSearchData, postSavedSearch} from '../../../../api/savedSearch.ts';
@@ -29,7 +29,7 @@ export default function SaveSearchDialog({
     const usedFormSubmit = useFormSubmit<SavedSearch>({
         defaultValues: {
             name: search.query || '',
-            public: false,
+            privacy: SavedSearchPrivacy.Secret,
         },
         onSubmit: async data => {
             const d = {

--- a/databox/client/src/components/Media/Search/SavedSearch/SavedSearchFields.tsx
+++ b/databox/client/src/components/Media/Search/SavedSearch/SavedSearchFields.tsx
@@ -1,10 +1,13 @@
-import {TextField} from '@mui/material';
+import {TextField, Typography} from '@mui/material';
 import React from 'react';
-import {SavedSearch} from '../../../../types.ts';
+import {SavedSearch, SavedSearchPrivacy} from '../../../../types.ts';
 import {useTranslation} from 'react-i18next';
 import {UseFormSubmitReturn} from '@alchemy/api';
-import {FormFieldErrors, FormRow, SwitchWidget} from '@alchemy/react-form';
+import {FormFieldErrors, FormRow, RadioWidget} from '@alchemy/react-form';
 import {RemoteErrors} from '@alchemy/react-form';
+import LockIcon from '@mui/icons-material/Lock';
+import LinkIcon from '@mui/icons-material/Link';
+import PublicIcon from '@mui/icons-material/Public';
 
 type Props = {
     usedFormSubmit: UseFormSubmitReturn<SavedSearch>;
@@ -36,10 +39,81 @@ export default function SavedSearchFields({usedFormSubmit}: Props) {
                 <FormFieldErrors field={'name'} errors={errors} />
             </FormRow>
             <FormRow>
-                <SwitchWidget
+                <RadioWidget
                     control={control}
-                    name={'public'}
-                    label={t('form.saved_search.public.label', 'Public')}
+                    name={'privacy'}
+                    label={t('form.saved_search.privacy.label', 'Privacy')}
+                    options={[
+                        {
+                            value: SavedSearchPrivacy.Secret,
+                            icon: LockIcon,
+                            label: (
+                                <>
+                                    <Typography>
+                                        {t(
+                                            'form.saved_search.privacy.secret.label',
+                                            'Secret'
+                                        )}
+                                    </Typography>
+                                    <Typography
+                                        variant={'body2'}
+                                        color={'text.secondary'}
+                                    >
+                                        {t(
+                                            'form.saved_search.privacy.secret.helper',
+                                            'Only you and granted users'
+                                        )}
+                                    </Typography>
+                                </>
+                            ),
+                        },
+                        {
+                            value: SavedSearchPrivacy.Private,
+                            icon: LinkIcon,
+                            label: (
+                                <>
+                                    <Typography>
+                                        {t(
+                                            'form.saved_search.privacy.private.label',
+                                            'Private'
+                                        )}
+                                    </Typography>
+                                    <Typography
+                                        variant={'body2'}
+                                        color={'text.secondary'}
+                                    >
+                                        {t(
+                                            'form.saved_search.privacy.private.helper',
+                                            'Accessible by link, not listed'
+                                        )}
+                                    </Typography>
+                                </>
+                            ),
+                        },
+                        {
+                            value: SavedSearchPrivacy.Public,
+                            icon: PublicIcon,
+                            label: (
+                                <>
+                                    <Typography>
+                                        {t(
+                                            'form.saved_search.privacy.public.label',
+                                            'Public'
+                                        )}
+                                    </Typography>
+                                    <Typography
+                                        variant={'body2'}
+                                        color={'text.secondary'}
+                                    >
+                                        {t(
+                                            'form.saved_search.privacy.public.helper',
+                                            'Listed to every user'
+                                        )}
+                                    </Typography>
+                                </>
+                            ),
+                        },
+                    ]}
                 />
             </FormRow>
             <RemoteErrors errors={remoteErrors} />

--- a/databox/client/src/types.ts
+++ b/databox/client/src/types.ts
@@ -540,6 +540,12 @@ export type SavedSearchData = {
     sortBy: SortBy[];
 };
 
+export enum SavedSearchPrivacy {
+    Secret = 0,
+    Private = 1,
+    Public = 2,
+}
+
 export interface SavedSearch
     extends
         IPermissions<{
@@ -549,7 +555,7 @@ export interface SavedSearch
         }>,
         Entity {
     name: string;
-    public?: boolean;
+    privacy?: SavedSearchPrivacy;
     createdAt: string;
     updatedAt: string;
     data: SavedSearchData;

--- a/databox/client/translations/en.json
+++ b/databox/client/translations/en.json
@@ -1750,8 +1750,20 @@
             "name": {
                 "label": "Name"
             },
-            "public": {
-                "label": "Public"
+            "privacy": {
+                "label": "Privacy",
+                "private": {
+                    "helper": "Accessible by link, not listed",
+                    "label": "Private"
+                },
+                "public": {
+                    "helper": "Listed to every user",
+                    "label": "Public"
+                },
+                "secret": {
+                    "helper": "Only you and granted users",
+                    "label": "Secret"
+                }
             }
         },
         "saved_search_edit": {

--- a/databox/client/translations/fr.json
+++ b/databox/client/translations/fr.json
@@ -1206,8 +1206,20 @@
             "title": "Créer un Profil"
         },
         "saved_search": {
-            "public": {
-                "label": "Public"
+            "privacy": {
+                "label": "Confidentialité",
+                "private": {
+                    "helper": "Accessible par lien, non listée",
+                    "label": "Privée"
+                },
+                "public": {
+                    "helper": "Listée pour tous les utilisateurs",
+                    "label": "Publique"
+                },
+                "secret": {
+                    "helper": "Seulement vous et les utilisateurs autorisés",
+                    "label": "Secrète"
+                }
             },
             "title": {
                 "label": "Titre"

--- a/lib/js/react-form/src/Widget/RadioWidget.tsx
+++ b/lib/js/react-form/src/Widget/RadioWidget.tsx
@@ -30,7 +30,7 @@ type Props<TFieldValues extends FieldValues> = {
 
 type RadioOption = {
     label: ReactNode;
-    value: string;
+    value: string | number;
     icon?: React.ElementType;
     disabled?: boolean;
 };
@@ -58,6 +58,7 @@ export default function RadioWidget<TFieldValues extends FieldValues>({
                         {...field}
                         sx={theme => ({
                             'flexDirection': 'row',
+                            'flexWrap': 'nowrap',
                             'gap': 2,
                             '> label': {
                                 'minWidth': 150,


### PR DESCRIPTION
Replace the public boolean on SavedSearch with a three-level privacy status: secret (owner and granted users only), private (accessible by direct link but not listed) and public (listed to every user).

The item endpoint, previously open to anyone knowing the ID, is now guarded by the READ voter which denies access to secret searches. Existing non-public searches are migrated to private to preserve link-based access (e.g. landing page widgets).