### PR TITLE
Configure Keycloak proxy headers for reverse proxy support

### DIFF
--- a/.env
+++ b/.env
@@ -449,6 +449,9 @@ KC_REALM_USER_EVENT_EXPIRATION=604800
 KC_REALM_ADMIN_EVENT_ENABLED=false
 KC_REALM_ADMIN_EVENT_EXPIRATION=604800
 
+# Keycloak proxy headers: "xforwarded", "forwarded", or empty if no proxy
+KC_PROXY_HEADERS=
+
 # @category auth
 # for second Identity Provider
 KEYCLOAK2_DB_NAME=keycloak2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -930,7 +930,7 @@ services:
       - KC_LOGIN_DISPLAY_DASHBOARD_LINK
       - KC_HEALTH_ENABLED=true
       - KC_HTTP_ENABLED=true
-      - KC_PROXY_HEADERS=xforwarded
+      - KC_PROXY_HEADERS
       - KC_PROXY_TRUSTED_ADDRESSES=${TRUSTED_PROXIES}
       - KC_BOOTSTRAP_ADMIN_USERNAME=${KEYCLOAK_ADMIN}
       - KC_BOOTSTRAP_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
@@ -939,7 +939,6 @@ services:
       - KC_DB_PASSWORD=${POSTGRES_PASSWORD}
       - KC_DB=postgres
       - KC_DB_URL=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${KEYCLOAK_DB_NAME}
-      - KC_PROXY_HEADERS
     extra_hosts:
       - keycloak2.${PHRASEA_DOMAIN}:${PS_GATEWAY_IP}
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -939,6 +939,7 @@ services:
       - KC_DB_PASSWORD=${POSTGRES_PASSWORD}
       - KC_DB=postgres
       - KC_DB_URL=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${KEYCLOAK_DB_NAME}
+      - KC_PROXY_HEADERS
     extra_hosts:
       - keycloak2.${PHRASEA_DOMAIN}:${PS_GATEWAY_IP}
     labels:


### PR DESCRIPTION
Fix Keycloak account settings redirect loop when running behind a reverse proxy.
Added the optional KC_PROXY_HEADERS configuration to properly handle X-Forwarded-* headers.