### PR TITLE
PS-1257 restrict basket read to authorized users

### DIFF
--- a/databox/api/src/Api/InputTransformer/AssetRenditionInputTransformer.php
+++ b/databox/api/src/Api/InputTransformer/AssetRenditionInputTransformer.php
@@ -21,8 +21,7 @@ class AssetRenditionInputTransformer extends AbstractFileInputTransformer
 
     public function __construct(
         private readonly AssetRenditionRepository $assetRenditionRepository,
-    )
-    {
+    ) {
     }
 
     public function supports(string $resourceClass, object $data): bool

--- a/databox/api/src/Consumer/Handler/Rendition/BuildDynamicRenditionHandler.php
+++ b/databox/api/src/Consumer/Handler/Rendition/BuildDynamicRenditionHandler.php
@@ -6,7 +6,6 @@ namespace App\Consumer\Handler\Rendition;
 
 use Alchemy\CoreBundle\Util\DoctrineUtil;
 use App\Entity\Core\AssetRendition;
-use App\Service\Asset\RenditionBuild\Exception\RenditionBuildException;
 use App\Service\Asset\RenditionBuilder;
 use App\Service\Storage\RenditionManager;
 use Doctrine\ORM\EntityManagerInterface;

--- a/databox/api/src/Entity/Basket/Basket.php
+++ b/databox/api/src/Entity/Basket/Basket.php
@@ -44,7 +44,8 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(
             normalizationContext: [
                 'groups' => [self::GROUP_READ],
-            ]
+            ],
+            security: 'is_granted("'.AbstractVoter::READ.'", object)',
         ),
         new Delete(security: 'is_granted("'.AbstractVoter::DELETE.'", object)'),
         new Put(

--- a/databox/api/tests/Api/BasketTest.php
+++ b/databox/api/tests/Api/BasketTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use Alchemy\AuthBundle\Tests\Client\KeycloakClientTestMock;
+use App\Tests\AbstractSearchTestCase;
+
+class BasketTest extends AbstractSearchTestCase
+{
+    public function testBasketIsNotVisibleToOtherUsers(): void
+    {
+        self::enableFixtures();
+        $client = static::createClient();
+
+        $response = $client->request('POST', '/baskets', [
+            'headers' => [
+                'Authorization' => 'Bearer '.KeycloakClientTestMock::getJwtFor(KeycloakClientTestMock::USER_UID),
+            ],
+            'json' => [
+                'name' => 'My private basket',
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $id = $response->toArray()['id'];
+
+        self::forceNewEntitiesToBeIndexed();
+        self::waitForESIndex('basket');
+
+        // Owner sees it
+        $response = $client->request('GET', '/baskets', [
+            'headers' => [
+                'Authorization' => 'Bearer '.KeycloakClientTestMock::getJwtFor(KeycloakClientTestMock::USER_UID),
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame([$id], array_column($response->toArray()['hydra:member'], 'id'));
+
+        // Other user does not see it in the list
+        $response = $client->request('GET', '/baskets', [
+            'headers' => [
+                'Authorization' => 'Bearer '.KeycloakClientTestMock::getJwtFor(KeycloakClientTestMock::OTHER_USER_UID),
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame([], array_column($response->toArray()['hydra:member'], 'id'));
+
+        // Other user cannot read it
+        $client->request('GET', '/baskets/'.$id, [
+            'headers' => [
+                'Authorization' => 'Bearer '.KeycloakClientTestMock::getJwtFor(KeycloakClientTestMock::OTHER_USER_UID),
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // Other user cannot list its assets
+        $client->request('GET', '/baskets/'.$id.'/assets', [
+            'headers' => [
+                'Authorization' => 'Bearer '.KeycloakClientTestMock::getJwtFor(KeycloakClientTestMock::OTHER_USER_UID),
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // Anonymous cannot read it
+        $client->request('GET', '/baskets/'.$id);
+        $this->assertResponseStatusCodeSame(401);
+    }
+}

--- a/databox/api/tests/Search/SearchTestTrait.php
+++ b/databox/api/tests/Search/SearchTestTrait.php
@@ -27,6 +27,7 @@ trait SearchTestTrait
             'collection',
             'attribute',
             'asset_data_template',
+            'basket',
         ];
         self::$documentIndices = [];
         foreach ($indexes as $indexName) {


### PR DESCRIPTION
GET /baskets/{id} had no security expression, so any authenticated user could read another user's basket by id. Apply the READ voter to the item operation and add a test covering list, item, assets and anonymous access.